### PR TITLE
Allow collection of specific version of workflow context

### DIFF
--- a/model_manager/dashboards/integration/modeldesigner/forms.py
+++ b/model_manager/dashboards/integration/modeldesigner/forms.py
@@ -3,6 +3,7 @@ import logging
 
 #from model_manager import api
 from django.conf import settings
+from django.core.urlresolvers import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.debug import sensitive_variables  # noqa
 from horizon import exceptions, forms, messages, workflows, forms as horizon_forms
@@ -90,3 +91,16 @@ class CreateCookiecutterForm(forms.SelfHandlingForm):
 
         return True
 
+
+def version_choices():
+    from .utils import ContextTemplateCollector
+    collector = ContextTemplateCollector()
+    versions = collector.collect_versions()
+    return [(v, v) for v in versions]
+
+
+class VersionForm(forms.SelfHandlingForm):
+    version = forms.ChoiceField(label='Version', choices=version_choices)
+
+    def handle(self, request, data):
+        return True

--- a/model_manager/dashboards/integration/modeldesigner/tables.py
+++ b/model_manager/dashboards/integration/modeldesigner/tables.py
@@ -31,12 +31,28 @@ class ShowDetail(tables.LinkAction):
 
 
 class CreateCookiecutter(tables.LinkAction):
-    name = "create_cookiecutter"
-    verbose_name = _("Create Model")
-    url = "horizon:integration:modeldesigner:create"
+    name = 'create_cookiecutter'
+    verbose_name = _('Create Model')
+    url = 'horizon:integration:modeldesigner:create'
 
     def get_link_url(self, datum=None):
         return reverse(self.url)
+
+    def allowed(self, request, datum):
+        return not getattr(settings, 'COOKIECUTTER_CONTEXT_VERSIONING_ENABLED', False)
+
+
+class CreateCookiecutterWithVersion(tables.LinkAction):
+    name = 'create_cookiecutter_with_version'
+    verbose_name = _('Create Model')
+    url = 'horizon:integration:modeldesigner:version'
+    classes = ('ajax-modal',)
+
+    def get_link_url(self, datum=None):
+        return reverse(self.url)
+
+    def allowed(self, request, datum):
+        return getattr(settings, 'COOKIECUTTER_CONTEXT_VERSIONING_ENABLED', False)
 
 
 class JobRow(tables.Row):
@@ -72,6 +88,6 @@ class CookiecutterTable(BuildTableBase):
         verbose_name = _("Cookiecutters")
         status_columns = ('result',)
         row_class = JobRow
-        table_actions = (CreateCookiecutter,)
+        table_actions = (CreateCookiecutter, CreateCookiecutterWithVersion)
         #row_actions = (ShowDetail,)
 

--- a/model_manager/dashboards/integration/modeldesigner/templates/modeldesigner/_version.html
+++ b/model_manager/dashboards/integration/modeldesigner/templates/modeldesigner/_version.html
@@ -1,0 +1,1 @@
+{% extends 'horizon/common/_modal_form.html' %}

--- a/model_manager/dashboards/integration/modeldesigner/templates/modeldesigner/version.html
+++ b/model_manager/dashboards/integration/modeldesigner/templates/modeldesigner/version.html
@@ -1,0 +1,1 @@
+{% include 'model_manager/modeldesigner/_version.html' %}

--- a/model_manager/dashboards/integration/modeldesigner/urls.py
+++ b/model_manager/dashboards/integration/modeldesigner/urls.py
@@ -7,6 +7,7 @@ urlpatterns = patterns(
     '',
     url(r'^$', views.IndexView.as_view(), name='index'),
     url(r'^create/$', views.CreateView.as_view(), name='create'),
+    url(r'^version/$', views.ContextVersionView.as_view(), name='version')
     #url(r'^(?P<build_id>[\w\.\-]+)/detail',
     #    views.DetailView.as_view(), name='detail'),
 )

--- a/model_manager/dashboards/integration/modeldesigner/utils.py
+++ b/model_manager/dashboards/integration/modeldesigner/utils.py
@@ -587,8 +587,9 @@ class GeneratedAction(workflows.Action):
         remote = self.context_template_remote or self.default_context_template_remote
         url = self.context_template_url or self.default_context_template_url
         token = self.context_template_token or self.default_context_template_token
+        version = self.request.GET.get('version')
         ctx_tmpl_collector = ContextTemplateCollector(remote=remote, url=url, token=token)
-        ctx_tmpl = ctx_tmpl_collector.collect_template()
+        ctx_tmpl = ctx_tmpl_collector.collect_template(version)
 
         return ctx_tmpl
 
@@ -688,8 +689,9 @@ class GeneratedStep(workflows.Step):
         remote = self.context_template_remote or self.default_context_template_remote
         url = self.context_template_url or self.default_context_template_url
         token = self.context_template_token or self.default_context_template_token
+        version = self.workflow.request.GET.get('version')
         ctx_tmpl_collector = ContextTemplateCollector(remote=remote, url=url, token=token)
-        ctx_tmpl = ctx_tmpl_collector.collect_template()
+        ctx_tmpl = ctx_tmpl_collector.collect_template(version)
 
         return ctx_tmpl
 

--- a/model_manager/dashboards/integration/modeldesigner/utils.py
+++ b/model_manager/dashboards/integration/modeldesigner/utils.py
@@ -261,7 +261,7 @@ class ContextTemplateCollector(object):
         if self.version_filter:
             regex = re.compile(self.version_filter)
             versions = filter(regex.search, versions)
-        return sorted(versions, reverse=True)
+        return sorted(versions)
 
 
 ######################################################

--- a/model_manager/dashboards/integration/modeldesigner/utils.py
+++ b/model_manager/dashboards/integration/modeldesigner/utils.py
@@ -64,6 +64,7 @@ class ContextTemplateCollector(object):
         default_project_name = getattr(settings, 'COOKIECUTTER_CONTEXT_PROJECT_NAME', None)
         default_file_name = getattr(settings, 'COOKIECUTTER_CONTEXT_FILE_NAME', None)
         default_version_filter = getattr(settings, 'COOKIECUTTER_CONTEXT_VERSION_FILTER', None)
+        default_version_map = getattr(settings, 'COOKIECUTTER_CONTEXT_VERSION_MAP', {})
 
         self.url = kwargs.get('url', default_url)
         self.path = kwargs.get('path', default_path)
@@ -75,6 +76,7 @@ class ContextTemplateCollector(object):
         self.project_name = kwargs.get('project_name', default_project_name)
         self.file_name = kwargs.get('file_name', default_file_name)
         self.version_filter = kwargs.get('version_filter', default_version_filter)
+        self.version_map = kwargs.get('version_map', default_version_map)
 
         self.collectors = {
             'github': {
@@ -258,9 +260,17 @@ class ContextTemplateCollector(object):
     def collect_versions(self):
         collector = self.collectors.get(self.remote, {}).get('version_collector', lambda: [])
         versions = collector()
+
+        # filter versions by configured regular expression
         if self.version_filter:
             regex = re.compile(self.version_filter)
             versions = filter(regex.search, versions)
+
+        # replace version names by names configured in version map
+        for idx, version in enumerate(versions):
+            if version in self.version_map:
+                versions[idx] = self.version_map[version]
+
         return sorted(versions)
 
 

--- a/model_manager/dashboards/integration/modeldesigner/utils.py
+++ b/model_manager/dashboards/integration/modeldesigner/utils.py
@@ -4,6 +4,7 @@ import crypt
 import io
 import json
 import logging
+import re
 import requests
 import socket
 import uuid
@@ -62,6 +63,7 @@ class ContextTemplateCollector(object):
         default_versions = getattr(settings, 'COOKIECUTTER_CONTEXT_VERSIONS', [])
         default_project_name = getattr(settings, 'COOKIECUTTER_CONTEXT_PROJECT_NAME', None)
         default_file_name = getattr(settings, 'COOKIECUTTER_CONTEXT_FILE_NAME', None)
+        default_version_filter = getattr(settings, 'COOKIECUTTER_CONTEXT_VERSION_FILTER', None)
 
         self.url = kwargs.get('url', default_url)
         self.path = kwargs.get('path', default_path)
@@ -72,6 +74,7 @@ class ContextTemplateCollector(object):
         self.versions = kwargs.get('versions', default_versions)
         self.project_name = kwargs.get('project_name', default_project_name)
         self.file_name = kwargs.get('file_name', default_file_name)
+        self.version_filter = kwargs.get('version_filter', default_version_filter)
 
         self.collectors = {
             'github': {
@@ -240,7 +243,11 @@ class ContextTemplateCollector(object):
 
     def collect_versions(self):
         collector = self.collectors.get(self.remote, {}).get('version_collector', lambda: [])
-        return collector()
+        versions = collector()
+        if self.version_filter:
+            regex = re.compile(self.version_filter)
+            versions = filter(regex.search, versions)
+        return sorted(versions, reverse=True)
 
 
 ######################################################

--- a/model_manager/dashboards/integration/modeldesigner/utils.py
+++ b/model_manager/dashboards/integration/modeldesigner/utils.py
@@ -109,6 +109,22 @@ class ContextTemplateCollector(object):
         return response_body
 
     def _gerrit_collector(self, version=None):
+        if not self.username:
+            msg = 'Gerrit username is required to be set as COOKIECUTTER_CONTEXT_USERNAME with COOKIECUTTER_CONTEXT_REMOTE = "gerrit".'
+            raise django_exc.ImproperlyConfigured(msg)
+        if not self.password:
+            msg = 'Gerrit password is required to be set as COOKIECUTTER_CONTEXT_PASSWORD with COOKIECUTTER_CONTEXT_REMOTE = "gerrit".'
+            raise django_exc.ImproperlyConfigured(msg)
+        if not self.url:
+            msg = 'Gerrit base URL is required to be set as COOKIECUTTER_CONTEXT_URL with COOKIECUTTER_CONTEXT_REMOTE = "gerrit".'
+            raise django_exc.ImproperlyConfigured(msg)
+        if not self.project_name:
+            msg = 'Gerrit project name is required to be set as COOKIECUTTER_CONTEXT_PROJECT_NAME with COOKIECUTTER_CONTEXT_REMOTE = "gerrit".'
+            raise django_exc.ImproperlyConfigured(msg)
+        if not self.file_name:
+            msg = 'Gerrit context file name is required to be set as COOKIECUTTER_CONTEXT_FILE_NAME with COOKIECUTTER_CONTEXT_REMOTE = "gerrit".'
+            raise django_exc.ImproperlyConfigured(msg)
+
         cache_key = 'workflow_context'
         endpoint_url = '/projects/%s/branches/master/files/%s/content' % (self.project_name, self.file_name)
         if version:

--- a/model_manager/dashboards/integration/modeldesigner/views.py
+++ b/model_manager/dashboards/integration/modeldesigner/views.py
@@ -4,13 +4,17 @@ import logging
 
 from model_manager.api.jenkins import jenkins_client
 from django.conf import settings
+from django.core.urlresolvers import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 from horizon import exceptions
+from horizon import forms
 from horizon import messages
 from horizon import tables
 from horizon import tabs
 from horizon import workflows
+from urllib import urlencode
 
+from .forms import VersionForm
 from .tables import CookiecutterTable, STATUS_CHOICES
 from .tabs import DetailTabGroup
 from .utils import AsyncWorkflowView
@@ -43,6 +47,22 @@ class IndexView(tables.DataTableView):
             builds = []
 
         return builds
+
+
+class ContextVersionView(forms.ModalFormView):
+    form_class = VersionForm
+    template_name = 'integration/modeldesigner/version.html'
+    modal_id = 'context_version_modal'
+    modal_header = _('Choose Context Version')
+    submit_label = _('Continue')
+    submit_url = reverse_lazy('horizon:integration:modeldesigner:version')
+
+    def get_success_url(self, **kwargs):
+        form = self.get_form()
+        version = form.data['version']
+        param = {'version': version}
+        url = reverse_lazy('horizon:integration:modeldesigner:create') + '?' + urlencode(param)
+        return url
 
 
 class CreateView(AsyncWorkflowView):

--- a/model_manager/settings/local/local_settings.py.example
+++ b/model_manager/settings/local/local_settings.py.example
@@ -36,6 +36,9 @@ COOKIECUTTER_CONTEXT_TOKEN = 'githubapitoken'
 # Allow multiple versions of context file, only Gerrit remote has version parsing from project implemented at this time
 COOKIECUTTER_CONTEXT_VERSIONING_ENABLED = True
 COOKIECUTTER_CONTEXT_VERSION_FILTER = '\d{4}\.\d{1,2}(\.\d{1,2})?' # only versions matching this regex are shown in the UI
+COOKIECUTTER_CONTEXT_VERSION_MAP = {
+    'master': 'nightly' # this will rename version master to version nightly
+}
 
 SALT_API_URL="http://127.0.0.1:8000"
 SALT_API_USER="saltdev"

--- a/model_manager/settings/local/local_settings.py.example
+++ b/model_manager/settings/local/local_settings.py.example
@@ -1,13 +1,41 @@
 SECRET_KEY = "secret"
 DEBUG = True
 
+# For all remotes
 JENKINS_API_URL = "localhost"
 JENKINS_API_USERNAME = "username"
 JENKINS_API_PASSWORD = "password"
 
 COOKIECUTTER_JENKINS_JOB = "cookiecutter-job"
+
+# Choose one of the context file locations bellow
+
+# HTTP remote
 COOKIECUTTER_CONTEXT_REMOTE = "http"
 COOKIECUTTER_CONTEXT_URL = "https://git.my-gitlab.io/group/project/raw/master/context.yaml"
+COOKIECUTTER_CONTEXT_USERNAME = 'username' # HTTP basic auth - optional
+COOKIECUTTER_CONTEXT_PASSWORD = 'password' # HTTP basic auth - optional
+
+# Gerrit remote
+COOKIECUTTER_CONTEXT_REMOTE = 'gerrit'
+COOKIECUTTER_CONTEXT_USERNAME = 'username' # Gerrit username
+COOKIECUTTER_CONTEXT_PASSWORD = 'password' # Gerrit HTTP password for given user, regular password with Gerrit LDAP auth
+COOKIECUTTER_CONTEXT_URL = 'https://gerrit.example.net'
+COOKIECUTTER_CONTEXT_PROJECT_NAME = 'full%2Fproject-name'
+COOKIECUTTER_CONTEXT_FILE_NAME = 'context.yaml'
+
+# Local FS remote
+COOKIECUTTER_CONTEXT_REMOTE = 'localfs'
+COOKIECUTTER_CONTEXT_PATH = '/path/to/context.yaml'
+
+# Github remote
+COOKIECUTTER_CONTEXT_REMOTE = 'github'
+COOKIECUTTER_CONTEXT_URL = 'https://api.github.com/repos/:owner/:repo/contents/:path'
+COOKIECUTTER_CONTEXT_TOKEN = 'githubapitoken'
+
+# Allow multiple versions of context file, only Gerrit remote has version parsing from project implemented at this time
+COOKIECUTTER_CONTEXT_VERSIONING_ENABLED = True
+COOKIECUTTER_CONTEXT_VERSION_FILTER = '\d{4}\.\d{1,2}(\.\d{1,2})?' # only versions matching this regex are shown in the UI
 
 SALT_API_URL="http://127.0.0.1:8000"
 SALT_API_USER="saltdev"


### PR DESCRIPTION
This PR adds: 
- Gerrit collector which uses Gerrit REST API
- Option to select one of available versions of context for workflow form in `/integration/create/` view. Version parsing is currently only available for Gerrit collector
- Single-letter variable names in existing collectors are expanded to be more verbose