### PR TITLE
Fix faulty implementation of form validation

### DIFF
--- a/model_manager/dashboards/integration/modeldesigner/utils.py
+++ b/model_manager/dashboards/integration/modeldesigner/utils.py
@@ -651,10 +651,9 @@ class GeneratedAction(workflows.Action):
         return str(string).replace('_', ' ').capitalize()
 
     def get_context_template(self):
-        if self.request.method == 'POST':
-            version = self.request.META.get('HTTP_X_HORIZON_CONTEXT_VERSION')
-        elif self.request.method == 'GET':
-            version = self.request.GET.get('version')
+        version = self.request.GET.get('version', None)
+        if not version:
+            version = self.request.META.get('HTTP_X_HORIZON_CONTEXT_VERSION', None)
         self.global_context['_cookiecutter_version'] = \
             version or getattr(settings, 'COOKIECUTTER_CONTEXT_DEFAULT_VERSION', '')
         ctx_tmpl_collector = ContextTemplateCollector()

--- a/model_manager/dashboards/integration/modeldesigner/workflows.py
+++ b/model_manager/dashboards/integration/modeldesigner/workflows.py
@@ -55,6 +55,9 @@ class CreateCookiecutterContext(workflows.Workflow):
                 if choice not in context.keys():
                     context[choice] = True if choice in context.values() else False
 
+    def get_absolute_url(self):
+        return self.request.get_full_path()
+
     def handle(self, request, context):
         """Handles any final processing for this workflow. Should return a
         boolean value indicating success.


### PR DESCRIPTION
Version should be always expected in GET first, because some requests are changed from POST to GET during POST request handling in Horizon workflow, current implementation led to weird states where some of the data were still fetched from incorrect version of workflow definition.